### PR TITLE
Fixed customizable binary name not in targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ LDFLAGS = -g -O3 -fopenmp
 
 all: $(LULESH_EXEC)
 
-lulesh2.0: $(OBJECTS2.0)
+$(LULESH_EXEC): $(OBJECTS2.0)
 	@echo "Linking"
 	$(CXX) $(OBJECTS2.0) $(LDFLAGS) -lm -o $@
 


### PR DESCRIPTION
For automation purposes we need to be able to generate unique filenames for binaries compiled with different flags, here is a fix to do this.