### PR TITLE
Fix overflows and inconsistencies of integer type use

### DIFF
--- a/lulesh-comm.cc
+++ b/lulesh-comm.cc
@@ -56,7 +56,7 @@
 
 
 /* doRecv flag only works with regular block structure */
-void CommRecv(Domain& domain, int msgType, Index_t xferFields,
+void CommRecv(Domain& domain, Int_t msgType, Index_t xferFields,
               Index_t dx, Index_t dy, Index_t dz, bool doRecv, bool planeOnly) {
 
    if (domain.numRanks() == 1)
@@ -354,7 +354,7 @@ void CommRecv(Domain& domain, int msgType, Index_t xferFields,
 
 /******************************************/
 
-void CommSend(Domain& domain, int msgType,
+void CommSend(Domain& domain, Int_t msgType,
               Index_t xferFields, Domain_member *fieldData,
               Index_t dx, Index_t dy, Index_t dz, bool doSend, bool planeOnly)
 {
@@ -845,7 +845,7 @@ void CommSend(Domain& domain, int msgType,
 
 /******************************************/
 
-void CommSBN(Domain& domain, int xferFields, Domain_member *fieldData) {
+void CommSBN(Domain& domain, Int_t xferFields, Domain_member *fieldData) {
 
    if (domain.numRanks() == 1)
       return ;

--- a/lulesh-init.cc
+++ b/lulesh-init.cc
@@ -15,7 +15,7 @@
 /////////////////////////////////////////////////////////////////////
 Domain::Domain(Int_t numRanks, Index_t colLoc,
                Index_t rowLoc, Index_t planeLoc,
-               Index_t nx, int tp, int nr, int balance, Int_t cost)
+               Index_t nx, Int_t tp, Int_t nr, Int_t balance, Int_t cost)
    :
    m_e_cut(Real_t(1.0e-7)),
    m_p_cut(Real_t(1.0e-7)),
@@ -401,7 +401,7 @@ void
 Domain::CreateRegionIndexSets(Int_t nr, Int_t balance)
 {
 #if USE_MPI   
-   Index_t myRank;
+   int myRank;
    MPI_Comm_rank(MPI_COMM_WORLD, &myRank) ;
    srand(myRank);
 #else

--- a/lulesh-util.cc
+++ b/lulesh-util.cc
@@ -7,8 +7,28 @@
 #endif
 #include "lulesh.h"
 
+/**
+ * Wrapper around strol and stroll
+ */
+template<typename IntT>
+typename
+std::enable_if<std::is_same<int, IntT>::value ||
+               std::is_same<long, IntT>::value, IntT>::type
+ParseString(const char *token, char **endptr, int base)
+{
+   return std::strtol(token, endptr, base);
+}
+
+template<typename IntT>
+typename std::enable_if<std::is_same<long long, IntT>::value, IntT>::type
+ParseString(const char *token, char **endptr, int base)
+{
+   return std::strtoll(token, endptr, base);
+}
+
 /* Helper function for converting strings to ints, with error checking */
-int StrToInt(const char *token, int *retVal)
+template<typename IntT>
+int StrToInt(const char *token, IntT *retVal)
 {
    const char *c ;
    char *endptr ;
@@ -18,7 +38,7 @@ int StrToInt(const char *token, int *retVal)
       return 0 ;
    
    c = token ;
-   *retVal = (int)strtol(c, &endptr, decimal_base) ;
+   *retVal = ParseString<IntT>(c, &endptr, decimal_base) ;
    if((endptr != c) && ((*endptr == ' ') || (*endptr == '\0')))
       return 1 ;
    else
@@ -58,7 +78,7 @@ static void ParseError(const char *message, int myRank)
 }
 
 void ParseCommandLineOptions(int argc, char *argv[],
-                             int myRank, struct cmdLineOpts *opts)
+                             Int_t myRank, struct cmdLineOpts *opts)
 {
    if(argc > 1) {
       int i = 1;

--- a/lulesh-util.cc
+++ b/lulesh-util.cc
@@ -176,9 +176,11 @@ void VerifyAndWriteFinalOutput(Real_t elapsed_time,
 {
    // GrindTime1 only takes a single domain into account, and is thus a good way to measure
    // processor speed indepdendent of MPI parallelism.
-   // GrindTime2 takes into account speedups from MPI parallelism 
-   Real_t grindTime1 = ((elapsed_time*1e6)/locDom.cycle())/(nx*nx*nx);
-   Real_t grindTime2 = ((elapsed_time*1e6)/locDom.cycle())/(nx*nx*nx*numRanks);
+   // GrindTime2 takes into account speedups from MPI parallelism.
+   // Cast to 64-bit integer to avoid overflows.
+   Int8_t nx8 = nx;
+   Real_t grindTime1 = ((elapsed_time*1e6)/locDom.cycle())/(nx8*nx8*nx8);
+   Real_t grindTime2 = ((elapsed_time*1e6)/locDom.cycle())/(nx8*nx8*nx8*numRanks);
 
    Index_t ElemId = 0;
    printf("Run completed:  \n");

--- a/lulesh-util.cc
+++ b/lulesh-util.cc
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <iostream>
+#include <iomanip>
 #if USE_MPI
 #include <mpi.h>
 #endif
@@ -203,11 +205,13 @@ void VerifyAndWriteFinalOutput(Real_t elapsed_time,
    Real_t grindTime2 = ((elapsed_time*1e6)/locDom.cycle())/(nx8*nx8*nx8*numRanks);
 
    Index_t ElemId = 0;
-   printf("Run completed:  \n");
-   printf("   Problem size        =  %i \n",    nx);
-   printf("   MPI tasks           =  %i \n",    numRanks);
-   printf("   Iteration count     =  %i \n",    locDom.cycle());
-   printf("   Final Origin Energy = %12.6e \n", locDom.e(ElemId));
+   std::cout << "Run completed:\n";
+   std::cout << "   Problem size        =  " << nx       << "\n";
+   std::cout << "   MPI tasks           =  " << numRanks << "\n";
+   std::cout << "   Iteration count     =  " << locDom.cycle() << "\n";
+   std::cout << "   Final Origin Energy =  ";
+   std::cout << std::scientific << std::setprecision(6);
+   std::cout << std::setw(12) << locDom.e(ElemId) << "\n";
 
    Real_t   MaxAbsDiff = Real_t(0.0);
    Real_t TotalAbsDiff = Real_t(0.0);
@@ -227,15 +231,19 @@ void VerifyAndWriteFinalOutput(Real_t elapsed_time,
    }
 
    // Quick symmetry check
-   printf("   Testing Plane 0 of Energy Array on rank 0:\n");
-   printf("        MaxAbsDiff   = %12.6e\n",   MaxAbsDiff   );
-   printf("        TotalAbsDiff = %12.6e\n",   TotalAbsDiff );
-   printf("        MaxRelDiff   = %12.6e\n\n", MaxRelDiff   );
+   std::cout << "   Testing Plane 0 of Energy Array on rank 0:\n";
+   std::cout << "        MaxAbsDiff   = " << std::setw(12) << MaxAbsDiff   << "\n";
+   std::cout << "        TotalAbsDiff = " << std::setw(12) << TotalAbsDiff << "\n";
+   std::cout << "        MaxRelDiff   = " << std::setw(12) << MaxRelDiff   << "\n";
 
    // Timing information
-   printf("\nElapsed time         = %10.2f (s)\n", elapsed_time);
-   printf("Grind time (us/z/c)  = %10.8g (per dom)  (%10.8g overall)\n", grindTime1, grindTime2);
-   printf("FOM                  = %10.8g (z/s)\n\n", 1000.0/grindTime2); // zones per second
+   std::cout.unsetf(std::ios_base::floatfield);
+   std::cout << std::setprecision(2);
+   std::cout << "\nElapsed time         = " << std::setw(10) << elapsed_time << " (s)\n";
+   std::cout << std::setprecision(8);
+   std::cout << "Grind time (us/z/c)  = "  << std::setw(10) << grindTime1 << " (per dom)  ("
+             << std::setw(10) << elapsed_time << " overall)\n";
+   std::cout << "FOM                  = " << std::setw(10) << 1000.0/grindTime2 << " (z/s)\n\n";
 
    return ;
 }

--- a/lulesh.cc
+++ b/lulesh.cc
@@ -2720,19 +2720,19 @@ int main(int argc, char *argv[])
    ParseCommandLineOptions(argc, argv, myRank, &opts);
 
    if ((myRank == 0) && (opts.quiet == 0)) {
-      printf("Running problem size %d^3 per domain until completion\n", opts.nx);
-      printf("Num processors: %d\n", numRanks);
+      std::cout << "Running problem size " << opts.nx << "^3 per domain until completion\n";
+      std::cout << "Num processors: "      << numRanks << "\n";
 #if _OPENMP
-      printf("Num threads: %d\n", omp_get_max_threads());
+      std::cout << "Num threads: " << omp_get_max_threads() << "\n";
 #endif
-      printf("Total number of elements: %lld\n\n", (long long int)(numRanks*opts.nx*opts.nx*opts.nx));
-      printf("To run other sizes, use -s <integer>.\n");
-      printf("To run a fixed number of iterations, use -i <integer>.\n");
-      printf("To run a more or less balanced region set, use -b <integer>.\n");
-      printf("To change the relative costs of regions, use -c <integer>.\n");
-      printf("To print out progress, use -p\n");
-      printf("To write an output file for VisIt, use -v\n");
-      printf("See help (-h) for more options\n\n");
+      std::cout << "Total number of elements: " << ((Int8_t)numRanks*opts.nx*opts.nx*opts.nx) << " \n\n";
+      std::cout << "To run other sizes, use -s <integer>.\n";
+      std::cout << "To run a fixed number of iterations, use -i <integer>.\n";
+      std::cout << "To run a more or less balanced region set, use -b <integer>.\n";
+      std::cout << "To change the relative costs of regions, use -c <integer>.\n";
+      std::cout << "To print out progress, use -p\n";
+      std::cout << "To write an output file for VisIt, use -v\n";
+      std::cout << "See help (-h) for more options\n\n";
    }
 
    // Set up the mesh and decompose. Assumes regular cubes for now
@@ -2776,8 +2776,11 @@ int main(int argc, char *argv[])
       LagrangeLeapFrog(*locDom) ;
 
       if ((opts.showProg != 0) && (opts.quiet == 0) && (myRank == 0)) {
-         printf("cycle = %d, time = %e, dt=%e\n",
-                locDom->cycle(), double(locDom->time()), double(locDom->deltatime()) ) ;
+         std::cout << "cycle = " << locDom->cycle()       << ", "
+                   << std::scientific
+                   << "time = " << double(locDom->time()) << ", "
+                   << "dt="     << double(locDom->deltatime()) << "\n";
+         std::cout.unsetf(std::ios_base::floatfield);
       }
    }
 

--- a/lulesh.cc
+++ b/lulesh.cc
@@ -2677,9 +2677,9 @@ void LagrangeLeapFrog(Domain& domain)
 
 int main(int argc, char *argv[])
 {
-  Domain *locDom ;
-   Int_t numRanks ;
-   Int_t myRank ;
+   Domain *locDom ;
+   int numRanks ;
+   int myRank ;
    struct cmdLineOpts opts;
 
 #if USE_MPI   

--- a/lulesh.h
+++ b/lulesh.h
@@ -31,9 +31,11 @@ typedef float        real4 ;
 typedef double       real8 ;
 typedef long double  real10 ;  // 10 bytes on x86
 
-typedef int    Index_t ; // array subscript and loop index
-typedef real8  Real_t ;  // floating point representation
-typedef int    Int_t ;   // integer representation
+typedef int32_t Int4_t ;
+typedef int64_t Int8_t ;
+typedef Int4_t  Index_t ; // array subscript and loop index
+typedef real8   Real_t ;  // floating point representation
+typedef Int4_t  Int_t ;   // integer representation
 
 enum { VolumeError = -1, QStopError = -2 } ;
 


### PR DESCRIPTION
I noticed that the computation of the FOM overflows easily (e.g., `s=400` on 1k nodes) due to the use of 32-bit integers. Trying to use 64-bit integers by defining `Int_t` as `uint64_t`, I noticed that there are several inconsistencies in the use of `Int_t` that break the build. This PR fixes these problems and changes most of the use of `printf` to `std::cout` to silence warnings about wrong format specifiers in that case.

AFAICS, the use of 64-bit integers becomes necessary starting from around 650^3 elements per process to avoid overflows (8*650^3 > `INT_MAX`). This PR does not change the default of using 32-bit.