### PR TITLE
change source description to be more accurate

### DIFF
--- a/stdpar/src/lulesh.cc
+++ b/stdpar/src/lulesh.cc
@@ -1,5 +1,5 @@
 /*
-  This is a Version 2.0 MPI + OpenMP implementation of LULESH
+  This is a Version 2.0 MPI + C++ Standard Parallel implementation of LULESH
 
                  Copyright (c) 2010-2013.
       Lawrence Livermore National Security, LLC.


### PR DESCRIPTION
This is just a small change in the opening description so that users know which version of they're looking at.