### PR TITLE
Use double precision for stdpar and avoid division by zero in RelDiff computation

### DIFF
--- a/stdpar/src/lulesh-util.cc
+++ b/stdpar/src/lulesh-util.cc
@@ -205,7 +205,7 @@ void VerifyAndWriteFinalOutput(Real_t elapsed_time,
 
          if (MaxAbsDiff <AbsDiff) MaxAbsDiff = AbsDiff;
 
-         Real_t RelDiff = AbsDiff / locDom.e(k*nx+j);
+         Real_t RelDiff = FABS(locDom.e(k*nx+j)) > 1e-8 ? AbsDiff / locDom.e(k*nx+j) : 0.0;
 
          if (MaxRelDiff <RelDiff)  MaxRelDiff = RelDiff;
       }

--- a/stdpar/src/lulesh.h
+++ b/stdpar/src/lulesh.h
@@ -35,7 +35,7 @@ typedef long double  real10 ;  // 10 bytes on x86
 typedef int32_t Int4_t ;
 typedef int64_t Int8_t ;
 typedef Int4_t  Index_t ; // array subscript and loop index
-typedef real4   Real_t ;  // floating point representation
+typedef real8   Real_t ;  // floating point representation
 typedef Int4_t  Int_t ;   // integer representation
 
 enum { VolumeError = -1, QStopError = -2 } ;


### PR DESCRIPTION
Use double precision for stdpar and avoid division by zero in RelDiff computation