### PR TITLE
Makefile: use gcc optimization flag -fipa-pta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SOURCES2.0 = \
 OBJECTS2.0 = $(SOURCES2.0:.cc=.o)
 
 #Default build suggestions with OpenMP for g++
-CXXFLAGS = -g -O3 -fopenmp -I. -Wall
+CXXFLAGS = -g -O3 -fopenmp -I. -Wall -fipa-pta
 LDFLAGS = -g -O3 -fopenmp
 
 #Below are reasonable default flags for a serial build


### PR DESCRIPTION
From gcc 4.2 (March 2009) the compiler has supported the -fipa-pta option that performs interprocedural pointer analysis and interprocedural modification and reference analysis. This is a useful optimization for lulesh and shows performance improvements as detailed below:

Toolchain	CPU		peformance improvement

g++ 14.2.0	Xeon 8380	0.2%
g++ 14.2.1	i9-12900	1.2%
g++ 13.2.0	i7-6700		1.2%